### PR TITLE
Add Cultura banner static block

### DIFF
--- a/src/components/admin/StaticBlockCreator.tsx
+++ b/src/components/admin/StaticBlockCreator.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Layout, Mail, Plus, Handshake } from "lucide-react";
+import { Layout, Mail, Plus, Handshake, Palette } from "lucide-react";
 import { STATIC_BLOCKS } from "../../constants/blocks";
 import type { StaticBlockType } from "../../types";
 
@@ -27,6 +27,8 @@ export function StaticBlockCreator({ onCreateBlock }: StaticBlockCreatorProps) {
                 <Mail className="w-5 h-5 text-primary" />
               ) : block.type === "donation" ? (
                 <Handshake className="w-5 h-5 text-primary" />
+              ) : block.type === "culturaBanner" ? (
+                <Palette className="w-5 h-5 text-amber-700" />
               ) : (
                 <Layout className="w-5 h-5 text-gray-500" />
               )}

--- a/src/components/blocks/CulturaBanner.server.tsx
+++ b/src/components/blocks/CulturaBanner.server.tsx
@@ -1,0 +1,133 @@
+import Link from "next/link";
+import { StaticBlock, StoryBlock } from "@/types";
+import { isDevelopment } from "@/services/config";
+import { loadGridStateLocal } from "@/services/local-storage";
+import { loadGridStateRedis } from "@/services/redis";
+import { getClient, GET_POST_BY_ID } from "@/services/wp-graphql";
+import { formatDate } from "@/utils/categoryUtils";
+
+interface CulturaBannerProps {
+  block: StaticBlock;
+}
+
+interface ResolvedStory {
+  uId: string;
+  uri: string;
+  title: string;
+  date: string;
+}
+
+async function getCulturaGridState() {
+  try {
+    if (isDevelopment) {
+      return await loadGridStateLocal("grid-state-cultura.json");
+    }
+    return await loadGridStateRedis("grid-state-cultura", "cultura-grid");
+  } catch {
+    return null;
+  }
+}
+
+async function resolveStory(
+  block: StoryBlock
+): Promise<ResolvedStory | null> {
+  const { data } = await getClient().query(GET_POST_BY_ID, {
+    id: block.databaseId.toString(),
+  });
+  const post = data?.post;
+  if (!post) return null;
+  return {
+    uId: block.uId,
+    uri: post.uri ?? "#",
+    title: block.title || post.title || "",
+    date: post.date || "",
+  };
+}
+
+export async function CulturaBannerServer({ block }: CulturaBannerProps) {
+  const gridState = await getCulturaGridState();
+  const storyBlocks = (gridState?.blocks ?? []).filter(
+    (b): b is StoryBlock => b.blockType === "story"
+  );
+  const latest = storyBlocks
+    .slice()
+    .sort((a, b) => b.uId.localeCompare(a.uId))
+    .slice(0, 5);
+
+  const resolved = (await Promise.all(latest.map(resolveStory))).filter(
+    (s): s is ResolvedStory => s !== null
+  );
+
+  const gridStyles = {
+    gridColumn: `span ${block.gridPosition?.width || 1}`,
+    gridRow: `span ${block.gridPosition?.height || 1}`,
+  };
+
+  return (
+    <article
+      className="group relative isolate h-full overflow-hidden rounded-md border border-amber-200/60 bg-gradient-to-br from-[#f5ecd9] via-[#f0e4c7] to-[#e8d9b0] shadow-sm block-content"
+      style={gridStyles}
+    >
+      <Link
+        href="/cultura"
+        aria-label="Ver secção Cultura"
+        className="absolute inset-0 z-10 transition-colors hover:bg-black/[0.02] focus-visible:outline-2 focus-visible:outline-amber-700"
+      />
+
+      <div
+        aria-hidden
+        className="pointer-events-none absolute -left-6 -top-10 text-[11rem] leading-none font-serif italic text-amber-900/5 select-none"
+      >
+        C
+      </div>
+
+      <div className="relative flex h-full flex-col gap-4 p-5 md:flex-row md:gap-6 md:p-6">
+        <header className="flex shrink-0 flex-col justify-between md:w-2/5">
+          <div>
+            <p className="font-serif text-[10px] uppercase tracking-[0.35em] text-amber-800/80">
+              Secção
+            </p>
+            <h2 className="mt-1 font-serif text-4xl font-bold leading-none text-stone-900 md:text-5xl lg:text-6xl">
+              Cultura
+            </h2>
+            <p className="mt-3 max-w-xs text-sm text-stone-700/90">
+              Livros, arte, ideias e ensaio no Página UM.
+            </p>
+          </div>
+          <span className="mt-4 inline-flex items-center gap-1 text-xs font-medium uppercase tracking-wider text-amber-900 transition-transform group-hover:translate-x-0.5">
+            Ver tudo
+            <span aria-hidden>→</span>
+          </span>
+        </header>
+
+        <ul className="flex-1 divide-y divide-amber-900/10">
+          {resolved.length === 0 && (
+            <li className="py-3 text-sm italic text-stone-600">
+              Sem histórias na grelha de Cultura.
+            </li>
+          )}
+          {resolved.map((story) => (
+            <li key={story.uId} className="relative z-20 py-2.5 first:pt-0">
+              <Link
+                href={story.uri}
+                className="block focus-visible:outline-2 focus-visible:outline-amber-700"
+              >
+                <h3 className="font-serif text-base leading-snug text-stone-900 hover:text-amber-900 md:text-[17px]">
+                  {story.title}
+                </h3>
+                {story.date && (
+                  <time
+                    dateTime={story.date}
+                    className="mt-0.5 block text-[11px] uppercase tracking-wider text-stone-500"
+                  >
+                    {formatDate(story.date)}
+                  </time>
+                )}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </article>
+  );
+}

--- a/src/components/blocks/CulturaBanner.server.tsx
+++ b/src/components/blocks/CulturaBanner.server.tsx
@@ -87,7 +87,7 @@ export async function CulturaBannerServer({ block }: CulturaBannerProps) {
             <p className="font-serif text-[10px] uppercase tracking-[0.35em] text-amber-800/80">
               Secção
             </p>
-            <h2 className="mt-1 font-serif text-4xl font-bold leading-none text-stone-900 md:text-5xl lg:text-6xl">
+            <h2 className="font-instrument mt-1 text-5xl font-normal leading-[0.9] tracking-tight text-stone-900 md:text-6xl lg:text-7xl">
               Cultura
             </h2>
             <p className="mt-3 max-w-xs text-sm text-stone-700/90">
@@ -100,33 +100,41 @@ export async function CulturaBannerServer({ block }: CulturaBannerProps) {
           </span>
         </header>
 
-        <ul className="flex-1 divide-y divide-amber-900/10">
-          {resolved.length === 0 && (
-            <li className="py-3 text-sm italic text-stone-600">
-              Sem histórias na grelha de Cultura.
-            </li>
-          )}
-          {resolved.map((story) => (
-            <li key={story.uId} className="relative z-20 py-2.5 first:pt-0">
-              <Link
-                href={story.uri}
-                className="block focus-visible:outline-2 focus-visible:outline-amber-700"
+        <div className="flex flex-1 flex-col">
+          <p className="mb-2 font-serif text-[10px] uppercase tracking-[0.35em] text-amber-800/80">
+            Recentes
+          </p>
+          <ul className="flex-1 divide-y divide-amber-900/10">
+            {resolved.length === 0 && (
+              <li className="py-3 text-sm italic text-stone-600">
+                Sem histórias na grelha de Cultura.
+              </li>
+            )}
+            {resolved.map((story) => (
+              <li
+                key={story.uId}
+                className="relative z-20 py-2.5 first:pt-0"
               >
-                <h3 className="font-serif text-base leading-snug text-stone-900 hover:text-amber-900 md:text-[17px]">
-                  {story.title}
-                </h3>
-                {story.date && (
-                  <time
-                    dateTime={story.date}
-                    className="mt-0.5 block text-[11px] uppercase tracking-wider text-stone-500"
-                  >
-                    {formatDate(story.date)}
-                  </time>
-                )}
-              </Link>
-            </li>
-          ))}
-        </ul>
+                <Link
+                  href={story.uri}
+                  className="block focus-visible:outline-2 focus-visible:outline-amber-700"
+                >
+                  <h3 className="font-serif text-base leading-snug text-stone-900 hover:text-amber-900 md:text-[17px]">
+                    {story.title}
+                  </h3>
+                  {story.date && (
+                    <time
+                      dateTime={story.date}
+                      className="mt-0.5 block text-[11px] uppercase tracking-wider text-stone-500"
+                    >
+                      {formatDate(story.date)}
+                    </time>
+                  )}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
       </div>
     </article>
   );

--- a/src/components/blocks/StaticBlock.tsx
+++ b/src/components/blocks/StaticBlock.tsx
@@ -126,13 +126,18 @@ export function StaticBlock({ block, isAdmin }: StaticBlockProps) {
             <p className="font-serif text-[10px] uppercase tracking-[0.35em] text-amber-800/80">
               Secção
             </p>
-            <h2 className="mt-1 font-serif text-4xl font-bold leading-none text-stone-900">
+            <h2 className="font-instrument mt-1 text-5xl font-normal leading-[0.9] tracking-tight text-stone-900">
               Cultura
             </h2>
           </div>
-          <p className="text-xs italic text-stone-600">
-            5 histórias mais recentes da grelha de Cultura (pré-visualização)
-          </p>
+          <div>
+            <p className="font-serif text-[10px] uppercase tracking-[0.35em] text-amber-800/80">
+              Recentes
+            </p>
+            <p className="mt-1 text-xs italic text-stone-600">
+              5 histórias mais recentes da grelha de Cultura (pré-visualização)
+            </p>
+          </div>
         </div>
       </div>
     );

--- a/src/components/blocks/StaticBlock.tsx
+++ b/src/components/blocks/StaticBlock.tsx
@@ -22,6 +22,7 @@ export function StaticBlock({ block, isAdmin }: StaticBlockProps) {
   const isDonationBlock = block.type === "donation";
   const isAccountsCounter = block.type === "accountsCounter";
   const isBookPresale = block.type === "bookPresale";
+  const isCulturaBanner = block.type === "culturaBanner";
 
   const gridStyles = {
     gridColumn: `span ${block.gridPosition?.width || 1}`,
@@ -104,6 +105,35 @@ export function StaticBlock({ block, isAdmin }: StaticBlockProps) {
         style={gridStyles}
       >
         <BookPresaleBlock />
+      </div>
+    );
+  }
+
+  if (isCulturaBanner) {
+    return (
+      <div
+        className="relative h-full overflow-hidden rounded-md border border-amber-200/60 bg-gradient-to-br from-[#f5ecd9] via-[#f0e4c7] to-[#e8d9b0] shadow-sm block-content"
+        style={gridStyles}
+      >
+        <div
+          aria-hidden
+          className="pointer-events-none absolute -left-6 -top-10 text-[9rem] leading-none font-serif italic text-amber-900/5 select-none"
+        >
+          C
+        </div>
+        <div className="relative flex h-full flex-col justify-between p-5">
+          <div>
+            <p className="font-serif text-[10px] uppercase tracking-[0.35em] text-amber-800/80">
+              Secção
+            </p>
+            <h2 className="mt-1 font-serif text-4xl font-bold leading-none text-stone-900">
+              Cultura
+            </h2>
+          </div>
+          <p className="text-xs italic text-stone-600">
+            5 histórias mais recentes da grelha de Cultura (pré-visualização)
+          </p>
+        </div>
       </div>
     );
   }

--- a/src/components/grid/NewsGrid.tsx
+++ b/src/components/grid/NewsGrid.tsx
@@ -1,6 +1,7 @@
 import { Block } from "@/types";
 import { NewsStoryServer } from "../blocks/NewsStory/NewsStory.server";
 import { StaticBlock as StaticBlockComponent } from "../blocks/StaticBlock";
+import { CulturaBannerServer } from "../blocks/CulturaBanner.server";
 import { EmptyState } from "../ui/EmptyState";
 import { CategoryBlockServer } from "../blocks/CategoryBlock.server";
 import { sortBlocksZigzagThenMobilePriority } from "@/utils/sorting";
@@ -54,6 +55,8 @@ export function NewsGrid({ blocks = [] }: NewsGridProps) {
                   excludePostIds={storyPostsIds}
                 />
               )
+            ) : block.blockType === "static" && block.type === "culturaBanner" ? (
+              <CulturaBannerServer block={block} />
             ) : (
               <StaticBlockComponent block={block} isAdmin={false} />
             )}

--- a/src/constants/blocks.ts
+++ b/src/constants/blocks.ts
@@ -77,6 +77,13 @@ export const STATIC_BLOCKS: Record<string, StaticBlockDefinition> = {
     content: "Correio Mercantil de Brás Cubas em pré-venda.",
     defaultSize: { width: 4, height: 3 },
   },
+  culturaBanner: {
+    type: "culturaBanner",
+    title: "Banner Cultura",
+    content:
+      "Banner destacado com as 5 histórias mais recentes da grelha de Cultura.",
+    defaultSize: { width: 6, height: 4 },
+  },
 };
 
 export const GRID_COLUMNS = 10;

--- a/src/hooks/useNavigation.ts
+++ b/src/hooks/useNavigation.ts
@@ -11,7 +11,7 @@ export function useNavigation() {
       { href: "/cat/opiniao", label: "Opinião" },
       { href: "/cat/entrevistas", label: "Entrevistas" },
       { href: "/cat/cronica", label: "Crónica" },
-      { href: "/cat/cultura", label: "Cultura" },
+      { href: "/cultura", label: "Cultura" },
     ],
     []
   );

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,4 +1,5 @@
 @import url("https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;500;600;700;800");
+@import url("https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&display=swap");
 
 @tailwind base;
 @tailwind components;
@@ -36,6 +37,10 @@
   border-color: rgb(146, 10, 10) !important;
 }
 @layer components {
+  .font-instrument {
+    font-family: "Instrument Serif", serif;
+  }
+
   .headline {
     @apply font-serif text-4xl font-bold leading-tight;
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -70,6 +70,7 @@ export const STATIC_BLOCK_TYPES = [
   "donation",
   "accountsCounter",
   "bookPresale",
+  "culturaBanner",
 ] as const;
 
 export type StaticBlockType = (typeof STATIC_BLOCK_TYPES)[number];


### PR DESCRIPTION
New static block "culturaBanner" available from both /admin and /admin-cultura. Renders a serif "Cultura" wordmark alongside the 5 most recent story entries from the cultura grid state (sorted by block uId, i.e. most recently added), each linking to its own post. The surrounding card links to /cultura.