### PR TITLE
Replace Playfair Display with Instrument Serif

### DIFF
--- a/src/app/author/[slug]/page.tsx
+++ b/src/app/author/[slug]/page.tsx
@@ -64,7 +64,7 @@ export default async function AuthorPage({
   if (!author) {
     return (
       <div className="container mx-auto px-4 py-8">
-        <h1 className="text-4xl font-serif font-bold mb-8 text-gray-900">
+        <h1 className="text-4xl font-serif mb-8 text-gray-900">
           Autor não encontrado
         </h1>
       </div>
@@ -86,7 +86,7 @@ export default async function AuthorPage({
           </div>
         )}
         <div>
-          <h1 className="text-4xl font-serif font-bold text-gray-900">
+          <h1 className="text-4xl font-serif text-gray-900">
             {author.name}
           </h1>
           {author.description && (
@@ -95,7 +95,7 @@ export default async function AuthorPage({
         </div>
       </div>
 
-      <h2 className="text-2xl font-serif font-bold mb-6 text-gray-800">
+      <h2 className="text-2xl font-serif mb-6 text-gray-800">
         Artigos de {author.name}
       </h2>
 
@@ -119,7 +119,7 @@ export default async function AuthorPage({
                 </div>
               )}
               <div className="p-6">
-                <h3 className="text-xl font-serif font-bold mb-3 group-hover:text-primary transition-colors">
+                <h3 className="text-xl font-serif mb-3 group-hover:text-primary transition-colors">
                   {post.title}
                 </h3>
 

--- a/src/app/cat/[slug]/page.tsx
+++ b/src/app/cat/[slug]/page.tsx
@@ -67,7 +67,7 @@ export default async function CategoryPage({
 
   return (
     <div className="container mx-auto px-4 py-8">
-      <h1 className="text-4xl font-serif font-bold mb-8 text-gray-900">
+      <h1 className="text-4xl font-serif mb-8 text-gray-900">
         {category?.name}
       </h1>
 
@@ -91,7 +91,7 @@ export default async function CategoryPage({
                 </div>
               )}
               <div className="p-6 pb-0">
-                <h2 className="text-xl font-serif font-bold mb-3 group-hover:text-primary transition-colors">
+                <h2 className="text-xl font-serif mb-3 group-hover:text-primary transition-colors">
                   {post.title}
                 </h2>
               </div>

--- a/src/app/donativos/page.tsx
+++ b/src/app/donativos/page.tsx
@@ -25,7 +25,7 @@ export default function ContribuirPage() {
     <>
       <main className=" mx-auto px-4 py-12 md:flex justify-center items-center gap-4">
         <div className="text-center mb-12 md:max-w-[400px] md:p-4">
-          <h1 className="text-4xl font-serif font-bold mb-6 text-gray-900">
+          <h1 className="text-4xl font-serif mb-6 text-gray-900">
             Só depende dos leitores.
           </h1>
           <p className="text-xl text-gray-600 mb-8 md:text-center">

--- a/src/app/donativos/sucesso/page.tsx
+++ b/src/app/donativos/sucesso/page.tsx
@@ -34,7 +34,7 @@ export default function SucessoPage({ searchParams }: SuccessPageProps) {
           </div>
 
           {/* Main Message */}
-          <h1 className="text-4xl font-serif font-bold mb-6 text-gray-900">
+          <h1 className="text-4xl font-serif mb-6 text-gray-900">
             Obrigado pela sua contribuição!
           </h1>
 

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -20,7 +20,7 @@ export default async function SearchPage({
       <div className="container mx-auto px-4 py-8">
         <div className="flex items-center mb-8">
           <Search className="mr-2" />
-          <h1 className="text-4xl font-serif font-bold text-gray-900">
+          <h1 className="text-4xl font-serif text-gray-900">
             Pesquisa
           </h1>
         </div>
@@ -57,7 +57,7 @@ export default async function SearchPage({
     <div className="container mx-auto px-4 py-8">
       <div className="flex items-center mb-8">
         <Search className="mr-2" />
-        <h1 className="text-4xl font-serif font-bold text-gray-900">
+        <h1 className="text-4xl font-serif text-gray-900">
           Artigos relacionados com: <span className="italic">"{query}"</span>
         </h1>
       </div>

--- a/src/app/tag/[slug]/page.tsx
+++ b/src/app/tag/[slug]/page.tsx
@@ -69,7 +69,7 @@ export default async function TagPage({
 
   return (
     <div className="container mx-auto px-4 py-8">
-      <h1 className="text-4xl font-serif font-bold mb-8 text-gray-900">
+      <h1 className="text-4xl font-serif mb-8 text-gray-900">
         {tag?.name}
       </h1>
 
@@ -93,7 +93,7 @@ export default async function TagPage({
                 </div>
               )}
               <div className="p-6 pb-0">
-                <h2 className="text-xl font-serif font-bold mb-3 group-hover:text-primary transition-colors">
+                <h2 className="text-xl font-serif mb-3 group-hover:text-primary transition-colors">
                   {post.title}
                 </h2>
               </div>

--- a/src/components/blocks/AccountsCounterBlock.tsx
+++ b/src/components/blocks/AccountsCounterBlock.tsx
@@ -37,7 +37,7 @@ export function AccountsCounterBlock() {
 
   return (
     <div className="h-full w-full flex flex-col items-center justify-center text-center gap-4 p-4 bg-primary-dark text-white rounded-md shadow">
-      <p className="font-serif text-xl sm:text-2xl font-bold leading-snug">
+      <p className="font-serif text-xl sm:text-2xl leading-snug">
         Há <span className=" font-mono">{time.days}</span> dias,{" "}
         <span className=" font-mono">{time.hours}</span> horas,{" "}
         <span className=" font-mono">{time.minutes}</span> minutos,{" "}

--- a/src/components/blocks/BookPresaleBlock.tsx
+++ b/src/components/blocks/BookPresaleBlock.tsx
@@ -29,7 +29,7 @@ export function BookPresaleBlock() {
           />
         </div>
         <div className="flex flex-col items-center md:items-start justify-center flex-1 min-w-0 book-presale-content">
-          <h2 className="font-serif text-2xl md:text-3xl font-bold text-yellow-900 mb-1 drop-shadow-sm text-center md:text-left break-words">
+          <h2 className="font-serif text-2xl md:text-3xl text-yellow-900 mb-1 drop-shadow-sm text-center md:text-left break-words">
             Correio Mercantil de Brás Cubas
           </h2>
           <div className="text-yellow-800 text-lg md:text-xl font-medium italic mb-2 text-center md:text-left">

--- a/src/components/blocks/CategoryBlockHeader.tsx
+++ b/src/components/blocks/CategoryBlockHeader.tsx
@@ -12,7 +12,7 @@ export function CategoryBlockHeader({ title, link }: CategoryBlockHeaderProps) {
     <div className="flex items-end justify-between mb-2 pb-1 px-2 lg:px-0">
       <div className="flex items-center gap-2">
         <Tag className="w-5 h-5 text-primary" />
-        <h2 className="font-serif text-2xl font-bold">{title}</h2>
+        <h2 className="font-serif text-2xl">{title}</h2>
       </div>
       <Link href={link} className="underline text-sm text-gray-500">
         Ver tudo

--- a/src/components/blocks/CategoryPostList.tsx
+++ b/src/components/blocks/CategoryPostList.tsx
@@ -58,7 +58,7 @@ const ArticleContent = ({
       <Link href={post.uri || "#"} className="block">
         <h3
           className={twMerge(
-            "font-serif text-lg font-semibold hover:text-primary transition-colors line-clamp-3 @3xl:line-clamp-3",
+            "font-serif text-lg hover:text-primary transition-colors line-clamp-3 @3xl:line-clamp-3",
             showAuthor && "text-xl"
           )}
         >

--- a/src/components/blocks/NewsStory/ClassicLayout.tsx
+++ b/src/components/blocks/NewsStory/ClassicLayout.tsx
@@ -239,7 +239,7 @@ export function ClassicStoryLayout({
 
           <h2
             className={twMerge(
-              "font-serif text-2xl font-bold mb-3 leading-tight text-pretty max-md:mt-3",
+              "font-serif text-2xl mb-3 leading-tight text-pretty max-md:mt-3",
               !isAdmin && "lg:group-hover:underline",
               shouldReverse && "lg:text-right",
               extraBigTitle && "text-3xl"

--- a/src/components/blocks/NewsStory/ModernLayout.tsx
+++ b/src/components/blocks/NewsStory/ModernLayout.tsx
@@ -67,7 +67,7 @@ export function ModernStoryLayout({
             </p>
           )}
 
-          <h2 className="font-serif text-2xl md:text-3xl font-bold mb-3 leading-tight">
+          <h2 className="font-serif text-2xl md:text-3xl mb-3 leading-tight">
             {!isAdmin ? (
               <Link href={uri}>{title}</Link>
             ) : (

--- a/src/components/blocks/PodcastBlock.tsx
+++ b/src/components/blocks/PodcastBlock.tsx
@@ -105,7 +105,7 @@ export function PodcastBlock() {
       <div className="flex items-center justify-between mb-6 pb-3 border-b border-gray-200">
         <div className="flex items-center gap-2">
           <Mic className="w-5 h-5 text-white" />
-          <h2 className="font-serif text-2xl font-bold text-white">{title}</h2>
+          <h2 className="font-serif text-2xl text-white">{title}</h2>
         </div>
       </div>
       <div className="flex-1 overflow-auto">

--- a/src/components/blocks/StaticBlock.tsx
+++ b/src/components/blocks/StaticBlock.tsx
@@ -31,7 +31,7 @@ export function StaticBlock({ block, isAdmin }: StaticBlockProps) {
   if (isDivider) {
     return (
       <div className="flex items-end gap-1 border-b-primary-dark border-b max-sm:pl-3">
-        <h2 className="font-serif text-3xl font-bold text-primary-dark ">
+        <h2 className="font-serif text-3xl text-primary-dark ">
           {isAdmin ? (
             <EditableText
               blockUid={block.uId}
@@ -54,7 +54,7 @@ export function StaticBlock({ block, isAdmin }: StaticBlockProps) {
       >
         <div className="flex flex-col items-center text-center text-white h-full justify-center">
           <Mail className="w-12 h-12 mb-4" />
-          <h2 className="font-serif text-2xl font-bold mb-2">
+          <h2 className="font-serif text-2xl mb-2">
             Subscreva a nossa newsletter
           </h2>
           <p className="mb-6 text-white/90">

--- a/src/components/post/PostHeader.tsx
+++ b/src/components/post/PostHeader.tsx
@@ -30,7 +30,7 @@ export function PostHeader({ post }: { post: PostBySlugData["data"] }) {
         {antetitulo}
       </h2>
       <h1
-        className="text-4xl md:text-5xl font-serif font-bold mb-3 md:mb-8"
+        className="text-4xl md:text-5xl font-serif mb-3 md:mb-8"
         dangerouslySetInnerHTML={{ __html: post?.postBy?.title || "" }}
       />
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;500;600;700;800");
+@import url("https://fonts.googleapis.com/css2?family=Instrument+Serif&display=swap");
 
 @tailwind base;
 @tailwind components;
@@ -21,7 +21,7 @@
   h4,
   h5,
   h6 {
-    font-family: "Playfair Display", serif;
+    font-family: "Instrument Serif", serif;
   }
 }
 .aligncenter {
@@ -37,15 +37,15 @@
 }
 @layer components {
   .headline {
-    @apply font-serif text-4xl font-bold leading-tight;
+    @apply font-serif text-4xl leading-tight;
   }
 
   .subheadline {
-    @apply font-serif text-xl font-medium leading-snug;
+    @apply font-serif text-xl leading-snug;
   }
 
   .article-title {
-    @apply font-serif text-2xl font-bold hover:text-primary transition-colors;
+    @apply font-serif text-2xl hover:text-primary transition-colors;
   }
 
   .btn-primary {
@@ -67,19 +67,19 @@
   }
 
   .wp-content h1 {
-    @apply text-4xl font-bold mb-6;
+    @apply text-4xl mb-6;
   }
 
   .wp-content h2 {
-    @apply text-3xl font-semibold mb-4;
+    @apply text-3xl mb-4;
   }
 
   .wp-content h3 {
-    @apply text-2xl font-medium mb-3;
+    @apply text-2xl mb-3;
   }
 
   .wp-content h4 {
-    @apply text-xl font-medium mb-2;
+    @apply text-xl mb-2;
   }
 
   .wp-content p {
@@ -183,7 +183,7 @@
 
 .thrv_wrapper > h2,
 h3 {
-  font-weight: 600;
+  font-weight: 400;
   font-size: 1.5rem;
   margin-top: 16px;
   margin-bottom: 8px;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -64,7 +64,7 @@ module.exports = {
           "color-mix(in srgb, var(--color-primary) 10%, white)",
       },
       fontFamily: {
-        serif: ["Playfair Display", "serif"],
+        serif: ["Instrument Serif", "serif"],
       },
       animation: {
         "fade-in": "fadeIn 0.3s ease-in-out",


### PR DESCRIPTION
## Summary
- Replace Playfair Display Google Font import with Instrument Serif
- Update Tailwind config and CSS base heading styles to use Instrument Serif
- Remove all `font-bold`, `font-semibold`, and `font-medium` from serif elements across 15 files — Instrument Serif only has a 400 weight, so any higher weight triggers synthetic (faux) bold rendering

## Test plan
- [ ] Verify headings render in Instrument Serif on homepage, article pages, category/tag/author pages
- [ ] Confirm no faux-bold artifacts (text should look clean, not artificially thickened)
- [ ] Check `.wp-content` headings in article body
- [ ] Verify `.thrv_wrapper` headings in legacy content

🤖 Generated with [Claude Code](https://claude.com/claude-code)